### PR TITLE
Fix genScoreCollector cron edge cases

### DIFF
--- a/src/scoreCollector.roomObject.js
+++ b/src/scoreCollector.roomObject.js
@@ -97,10 +97,10 @@ module.exports = function(config) {
                     x2: 48 - radius,
                     y1: 2 + radius,
                     y2: 48 - radius
-                });
+                }).catch(() => false);
                 if (!freePos) {
                     console.log(`No free position for score collector in ${room._id}`);
-                    return;
+                    continue;
                 }
 
                 const structures = [];


### PR DESCRIPTION
This fixes 2 edge cases in the genScoreCollectors cron
One is that rooms without a free space cause findFreePos to throw (via reject), my fix is to catch that and return false instead
The second is that it was returning if a position couldn't be found, which keeps other rooms from even being attempted.
The trigger for these is the `out of borders` solid rooms that I have on my generated maps.